### PR TITLE
Add quiet option to skip confirmation prompt

### DIFF
--- a/cats/cats.py
+++ b/cats/cats.py
@@ -185,7 +185,7 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 )
 @click.option(
     "-p",
-    "--pushtx",
+    "--push",
     is_flag=True,
     help="Automatically push transaction to the network in quiet mode",
 )
@@ -203,7 +203,7 @@ def cli(
     as_bytes: bool,
     select_coin: bool,
     quiet: bool,
-    pushtx: bool
+    push: bool
 ):
     ctx.ensure_object(dict)
 
@@ -285,7 +285,7 @@ def cli(
     else:
         final_bundle_dump = json.dumps(final_bundle.to_json_dict(), sort_keys=True, indent=4)
 
-    confirmation = pushtx
+    confirmation = push
 
     if not quiet:
         confirmation = input(

--- a/cats/cats.py
+++ b/cats/cats.py
@@ -177,6 +177,18 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
     is_flag=True,
     help="Stop the process once a coin from the wallet has been selected and return the coin",
 )
+@click.option(
+    "-q",
+    "--quiet",
+    is_flag=True,
+    help="Quiet mode will not ask to push transaction to the network",
+)
+@click.option(
+    "-y",
+    "--yes",
+    is_flag=True,
+    help="Automatically push transaction to the network",
+)
 def cli(
     ctx: click.Context,
     tail: str,
@@ -190,6 +202,8 @@ def cli(
     spend: Tuple[str],
     as_bytes: bool,
     select_coin: bool,
+    quiet_mode: bool,
+    auto_push: bool
 ):
     ctx.ensure_object(dict)
 
@@ -271,9 +285,12 @@ def cli(
     else:
         final_bundle_dump = json.dumps(final_bundle.to_json_dict(), sort_keys=True, indent=4)
 
-    confirmation = input(
-        "The transaction has been created, would you like to push it to the network? (Y/N)"
-    ) in ["y", "Y", "yes", "Yes"]
+    confirmation = auto_push
+
+    if not quiet_mode:
+        confirmation = input(
+            "The transaction has been created, would you like to push it to the network? (Y/N)"
+        ) in ["y", "Y", "yes", "Yes"]
     if confirmation:
         response = asyncio.get_event_loop().run_until_complete(
             push_tx(fingerprint, final_bundle)

--- a/cats/cats.py
+++ b/cats/cats.py
@@ -184,10 +184,10 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
     help="Quiet mode will not ask to push transaction to the network",
 )
 @click.option(
-    "-y",
-    "--yes",
+    "-p",
+    "--pushtx",
     is_flag=True,
-    help="Automatically push transaction to the network",
+    help="Automatically push transaction to the network in quiet mode",
 )
 def cli(
     ctx: click.Context,
@@ -202,8 +202,8 @@ def cli(
     spend: Tuple[str],
     as_bytes: bool,
     select_coin: bool,
-    quiet_mode: bool,
-    auto_push: bool
+    quiet: bool,
+    pushtx: bool
 ):
     ctx.ensure_object(dict)
 
@@ -285,9 +285,9 @@ def cli(
     else:
         final_bundle_dump = json.dumps(final_bundle.to_json_dict(), sort_keys=True, indent=4)
 
-    confirmation = auto_push
+    confirmation = pushtx
 
-    if not quiet_mode:
+    if not quiet:
         confirmation = input(
             "The transaction has been created, would you like to push it to the network? (Y/N)"
         ) in ["y", "Y", "yes", "Yes"]


### PR DESCRIPTION
Adds a quite option to skip confirmation prompt and another option to automatically push the transaction in quiet mode.

The new prompt was interfering with an automated minting process I have.