### PR TITLE
Install Dependencies Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ python3 -m venv venv
 . ./venv/bin/activate
 python -m pip install --upgrade pip setuptools wheel
 pip install .
+pip install chia-dev-tools --no-deps
+pip install pytest
 ```
 (If you're on an M1 Mac, make sure you are running an ARM64 native python virtual environment)
 
@@ -23,6 +25,16 @@ py -m venv venv
 ./venv/Scripts/activate
 python -m pip install --upgrade pip setuptools wheel
 pip install .
+pip install chia-dev-tools --no-deps
+pip install pytest
 ```
 
 Lastly this requires a synced, running light wallet
+
+Verify the installation was successful
+```
+cats --help
+cdv --help
+```
+
+Examples can be found in the [CAT Creation Tutorial](https://docs.chia.net/guides/cat-creation-tutorial/#cat-admin-tool)


### PR DESCRIPTION
The install instructions do not include the installation of chia dev tools or pytest which are required for the examples provided in https://docs.chia.net/guides/cat-creation-tutorial/#cat-admin-tool .