### PR TITLE
Update fetch-depth for pre-commit workflow and pin ruff to 0.12.11

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -61,6 +61,8 @@ jobs:
           git config --global core.autocrlf false
 
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - uses: Chia-Network/actions/setup-python@main
         with:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ dev_dependencies = [
     "pre-commit==4.3.0; python_version >= '3.9'",
     "mypy==1.17.1",
     "types-setuptools",
-    "ruff>=0.8.1",
+    "ruff==0.12.11",
 ]
 
 setup(


### PR DESCRIPTION
Update fetch-depth:0 for pre-commit and pin ruff to 0.12.11 to match chia-blockchain 
