### PR TITLE
Remove support for python3.9 and move core ops to 3.12

### DIFF
--- a/.github/workflows/nightly-against-main.yml
+++ b/.github/workflows/nightly-against-main.yml
@@ -20,40 +20,40 @@ jobs:
       BLOCKS_AND_PLOTS_VERSION: 0.29.0
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
+      - name: Checkout Code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
-    - name: Setup Python environment
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.10'
+      - name: Setup Python environment
+        uses: Chia-Network/actions/setup-python@main
+        with:
+          python-version: "3.12"
 
-    - name: Cache test blocks and plots
-      uses: actions/cache@v4
-      env:
-        SEGMENT_DOWNLOAD_TIMEOUT_MIN: 1
-      id: test-blocks-plots
-      with:
-        path: |
-          ${{ github.workspace }}/.chia/blocks
-          ${{ github.workspace }}/.chia/test-plots
-        key: ${{ env.BLOCKS_AND_PLOTS_VERSION }}
+      - name: Cache test blocks and plots
+        uses: actions/cache@v4
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 1
+        id: test-blocks-plots
+        with:
+          path: |
+            ${{ github.workspace }}/.chia/blocks
+            ${{ github.workspace }}/.chia/test-plots
+          key: ${{ env.BLOCKS_AND_PLOTS_VERSION }}
 
-    - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        gh release download -R Chia-Network/test-cache ${{ env.BLOCKS_AND_PLOTS_VERSION }} --archive=tar.gz -O - | tar xzf -
-        mkdir "${GITHUB_WORKSPACE}/.chia"
-        mv "${GITHUB_WORKSPACE}/test-cache-${{ env.BLOCKS_AND_PLOTS_VERSION }}/"* "${GITHUB_WORKSPACE}/.chia"
+      - name: Checkout test blocks and plots
+        if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download -R Chia-Network/test-cache ${{ env.BLOCKS_AND_PLOTS_VERSION }} --archive=tar.gz -O - | tar xzf -
+          mkdir "${GITHUB_WORKSPACE}/.chia"
+          mv "${GITHUB_WORKSPACE}/test-cache-${{ env.BLOCKS_AND_PLOTS_VERSION }}/"* "${GITHUB_WORKSPACE}/.chia"
 
-    - name: Test code with pytest against chia-blockchain main nightly
-      run: |
-        python3 -m venv venv
-        . ./venv/bin/activate
-        sed -i 's/chia-blockchain.*/chia-blockchain @ git+https:\/\/github.com\/Chia-Network\/chia-blockchain.git@main\",/g' setup.py
-        pip install .[dev]
-        ./venv/bin/pytest tests/ -s -v --durations 0
+      - name: Test code with pytest against chia-blockchain main nightly
+        run: |
+          python3 -m venv venv
+          . ./venv/bin/activate
+          sed -i 's/chia-blockchain.*/chia-blockchain @ git+https:\/\/github.com\/Chia-Network\/chia-blockchain.git@main\",/g' setup.py
+          pip install .[dev]
+          ./venv/bin/pytest tests/ -s -v --durations 0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -40,7 +40,6 @@ jobs:
           - name: Intel
             matrix: intel
         python:
-          - major_dot_minor: "3.9"
           - major_dot_minor: "3.10"
           - major_dot_minor: "3.11"
           - major_dot_minor: "3.12"

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -6,10 +6,10 @@ on:
     branches:
       - main
     tags:
-        - '**'
+      - "**"
   pull_request:
     branches:
-      - '**'
+      - "**"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}--${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/long_lived/')) && github.sha || '' }}
@@ -29,39 +29,39 @@ jobs:
       BLOCKS_AND_PLOTS_VERSION: 0.29.0
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
+      - name: Checkout Code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
-    - name: Setup Python environment
-      uses: actions/setup-python@v6
-      with:
-        python-version: 3.9
+      - name: Setup Python environment
+        uses: Chia-Network/actions/setup-python@main
+        with:
+          python-version: 3.12
 
-    - name: Cache test blocks and plots
-      uses: actions/cache@v4
-      env:
-        SEGMENT_DOWNLOAD_TIMEOUT_MIN: 1
-      id: test-blocks-plots
-      with:
-        path: |
-          ${{ github.workspace }}/.chia/blocks
-          ${{ github.workspace }}/.chia/test-plots
-        key: ${{ env.BLOCKS_AND_PLOTS_VERSION }}
+      - name: Cache test blocks and plots
+        uses: actions/cache@v4
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 1
+        id: test-blocks-plots
+        with:
+          path: |
+            ${{ github.workspace }}/.chia/blocks
+            ${{ github.workspace }}/.chia/test-plots
+          key: ${{ env.BLOCKS_AND_PLOTS_VERSION }}
 
-    - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        gh release download -R Chia-Network/test-cache ${{ env.BLOCKS_AND_PLOTS_VERSION }} --archive=tar.gz -O - | tar xzf -
-        mkdir "${GITHUB_WORKSPACE}/.chia"
-        mv "${GITHUB_WORKSPACE}/test-cache-${{ env.BLOCKS_AND_PLOTS_VERSION }}/"* "${GITHUB_WORKSPACE}/.chia"
+      - name: Checkout test blocks and plots
+        if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download -R Chia-Network/test-cache ${{ env.BLOCKS_AND_PLOTS_VERSION }} --archive=tar.gz -O - | tar xzf -
+          mkdir "${GITHUB_WORKSPACE}/.chia"
+          mv "${GITHUB_WORKSPACE}/test-cache-${{ env.BLOCKS_AND_PLOTS_VERSION }}/"* "${GITHUB_WORKSPACE}/.chia"
 
-    - name: Test code with pytest
-      run: |
-        python3 -m venv venv
-        . ./venv/bin/activate
-        pip install .[dev]
-        ./venv/bin/pytest tests/ -s -v --durations 0
+      - name: Test code with pytest
+        run: |
+          python3 -m venv venv
+          . ./venv/bin/activate
+          pip install .[dev]
+          ./venv/bin/pytest tests/ -s -v --durations 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=42",
-    "setuptools_scm[toml]>=4.1.2",
+    "setuptools>=80",
+    "setuptools_scm[toml]>=8",
 ]
 build-backend = "setuptools.build_meta"
-
-[tool.setuptools_scm]
-fallback_version = "unknown-no-.git-directory"
-local_scheme = "no-local-version"

--- a/ruff.toml
+++ b/ruff.toml
@@ -49,6 +49,7 @@ ignore = [
 
     # Flake8 async
     # Should probably fix these
+    "ASYNC250", # blocking-input-call-in-async-function
     "ASYNC230", # blocking-open-call-in-async-function
     # Should probably fix these after dealing with shielding for anyio
     "ASYNC109", # async-function-with-timeout
@@ -64,6 +65,11 @@ ignore = [
     "RUF009", # function-call-in-dataclass-default-argument
     # Should probably fix this
     "RUF029",
+
+    # TODO: Remove these
+    "UP045",
+    "UP007",
+    "UP035"
 ]
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -49,7 +49,6 @@ ignore = [
 
     # Flake8 async
     # Should probably fix these
-    "ASYNC250", # blocking-input-call-in-async-function
     "ASYNC230", # blocking-open-call-in-async-function
     # Should probably fix these after dealing with shielding for anyio
     "ASYNC109", # async-function-with-timeout

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ dev_dependencies = [
     "pytest",
     "pytest-asyncio>=0.26.0",
     "pytest-env",
-    "pre-commit==4.3.0; python_version >= '3.9'",
+    "pre-commit==4.3.0; python_version >= '3.10'",
     "mypy==1.18.2",
     "types-setuptools",
     "ruff==0.12.11",
@@ -40,7 +40,6 @@ setup(
     description="Tools to administer issuance and redemption of a Chia Asset Token or CAT",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
This PR drops support for Python3.9 which is EOL at the end of October and switches core operations from 3.10 (now the lowest supported version) to 3.12.

(My editor also linted the yaml)